### PR TITLE
Draft for st.get_url and st.set_url

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -254,6 +254,7 @@ export class App extends PureComponent<Props, State> {
         uploadReportProgress: (progress: string | number) =>
           this.handleUploadReportProgress(progress),
         reportUploaded: (url: string) => this.handleReportUploaded(url),
+        newUrl: (new_url: string) => this.handleNewUrlChange(new_url),
       })
     } catch (err) {
       logError(err)
@@ -320,6 +321,11 @@ export class App extends PureComponent<Props, State> {
     })
 
     this.handleSessionStateChanged(sessionState)
+
+    // send current URL to server
+    const backMsg = new BackMsg({ urlInfo: window.location.href })
+    backMsg.type = "urlInfo"
+    this.sendBackMsg(backMsg)
   }
 
   /**
@@ -433,6 +439,14 @@ export class App extends PureComponent<Props, State> {
     } else {
       this.clearAppState(newReportHash, reportId, reportName)
     }
+  }
+
+  /**
+   * Handler for ForwardMsg.newUrl messages
+   * @param newUrl string
+   */
+  handleNewUrlChange = (newUrl: string): void => {
+    window.history.pushState({}, "", newUrl)
   }
 
   /**

--- a/lib/streamlit/ReportSession.py
+++ b/lib/streamlit/ReportSession.py
@@ -105,6 +105,8 @@ class ReportSession(object):
         self._script_request_queue = ScriptRequestQueue()
 
         self._scriptrunner = None
+        self.base_url = None
+        self.query_url = ''
 
         LOGGER.debug("ReportSession initialized (id=%s)", self.id)
 

--- a/lib/streamlit/server/Server.py
+++ b/lib/streamlit/server/Server.py
@@ -545,6 +545,9 @@ class _BrowserWebSocketHandler(tornado.websocket.WebSocketHandler):
                         "Client tried to close connection when "
                         "not in development mode"
                     )
+            elif msg_type == "url_info":
+                self._session.base_url = msg.url_info
+                LOGGER.debug("Successfully set base URL :\n%s", msg.url_info)
             else:
                 LOGGER.warning('No handler for "%s"', msg_type)
 

--- a/proto/streamlit/proto/BackMsg.proto
+++ b/proto/streamlit/proto/BackMsg.proto
@@ -88,5 +88,8 @@ message BackMsg {
 
     // Delete uploaded file
     DeleteUploadedFile delete_uploaded_file = 13;
+
+    // Request to pass current URL to backend
+    string url_info = 14;
   }
 }

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -72,6 +72,12 @@ message ForwardMsg {
     // for this one. If the client does not have the referenced message
     // in its cache, it can retrieve it from the server.
     string ref_hash = 11;
+
+    // new_url for curious users to set params
+    string new_url = 12;
+
+    // get_url for curious users to use in Streamlit
+    bool get_url = 13;
   }
 }
 


### PR DESCRIPTION
As discussed in #798, #302 and #1098, we are proposing a simple PR to add capability to set and get current URLs in user’s browser tab.
 
**Feature:**
User can call `st.set_url` => to append any query params after current hostname.
Example: if user’s current browser tab is http://localhost:3000 and user called st.set_url(“checkbox1=true&multiselect2=2”), the user’s browser tab will become http://localhost:3000/checkbox1=true&multiselect2=2 and this will NOT cause a redirect action.
 
User can call `st.get_url` => to get the current or new url set by `st.set_url`.
Example: if user hasn’t modified current URL via `st.set_url` => `st.get_url` will merely return the original url upon first connect. i.e. http://localhost:3000
if user has set the URL via `st.set_url` => `st.get_url` will return the modified url path, like http://localhost:3000/checkbox1=true&multiselect2=2
 
Note1: `st.get_url` will not return the updated URL set by ad-hoc javscript functions
 
**Implementation:**
Two new fields are added to ReportSession: base_url and query_url
 
Frontend will send current URL via a BackMsg upon first connect to Server. Server will receive the message and set base_url accordingly.
 
When `st.get_url` is called: server will return the concatenation of current ReportSession’s base_url and query_url (if any)
When `st.set_url` is called: server will set current ReportSession’s query_url and send a ForwardMsg to client to update browser address bar